### PR TITLE
Travis échoue quand les tests du frontend échouent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,8 +120,8 @@ script:
   - |
     # test and build frontend
     if [[ "$ZDS_TEST_JOB" == *"front"* ]]; then
-      yarn test
-      yarn build # we need to upload the assets later
+      yarn test \
+      && yarn build # we need to upload the assets later
     fi
 
   - |


### PR DESCRIPTION
Petite erreur de ma part.

Notez qu’on ne peut pas `set -e` dans Travis (sinon ça serait trop facile).

J’ai trouvé ça en relisant le `.travis.yml`.

| Q                                   | R
| ----------------------------------- | -------------------------------------------
| Type de modification                | correction de bug
| Ticket(s) (_issue(s)_) concerné(s)  | aucun

### QA

Regardez le diff.