### PR TITLE
Explicite l’import relatif de zds.settings_prod

### DIFF
--- a/zds/settings.py
+++ b/zds/settings.py
@@ -674,7 +674,7 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Load the production settings, overwrite the existing ones if needed
 try:
-    from settings_prod import *  # noqa
+    from .settings_prod import *  # noqa
 except ImportError:
     pass
 


### PR DESCRIPTION
Ça marchait avec Python 2, mais ça marche légèrement moins bien avec Python 3.
